### PR TITLE
Add account deactivation and password change features

### DIFF
--- a/src/main/ML.Api/Controllers/v1/AccountController.cs
+++ b/src/main/ML.Api/Controllers/v1/AccountController.cs
@@ -10,6 +10,7 @@ namespace ML.Api.Controllers.v1;
 public class AccountController(ISender sender) : BaseController
 {
     //change password
+    [HttpPost("change-password")]
     public async ValueTask<ActionResult<Result>> ChangePassword([FromBody] ChangePasswordCommand command)
     {
         var result = await sender.Send(command);
@@ -17,6 +18,16 @@ public class AccountController(ISender sender) : BaseController
     }
 
     //deactivate account
+    [HttpDelete("deactivate-account")]
+    public async ValueTask<ActionResult<Result>> DeactivateAccount()
+    {
+        var result = await sender.Send(new DeactivateAccountCommand());
+        return result.Succeeded ? Ok(result) : BadRequest(result);
+    }
 
-    //delete account, pass users email for admin only
+    //activate account - admin only
+
+    //view users - admin only
+
+    //delete account, pass users email for admin only add field (isPermamant and set default to false)
 }

--- a/src/main/ML.Application/Accounts/Commands/DeactivateAccount.cs
+++ b/src/main/ML.Application/Accounts/Commands/DeactivateAccount.cs
@@ -1,0 +1,23 @@
+﻿using MediatR;
+using ML.Application.Common.Interfaces;
+using ML.Application.Common.Models;
+using ML.Domain.Enums;
+
+namespace ML.Application.Accounts.Commands;
+
+public class DeactivateAccountCommand : IRequest<Result>
+{
+}
+
+internal class DeactivateAccountCommandHandler(IIdentityService identityService, IPublisher publisher) : IRequestHandler<DeactivateAccountCommand, Result>
+{
+    public async Task<Result> Handle(DeactivateAccountCommand request, CancellationToken cancellationToken)
+    {
+        var result = await identityService.DeactivateAccountAsync();
+        if(result.Item1.Succeeded)
+        {
+            await publisher.Publish(new NotificationEvent(result.usersEmail, "Sorry To See You Go!", NotificationTypeEnum.SignUpSuccess, []), cancellationToken);
+        }
+        return result.Item1;
+    }
+}

--- a/src/main/ML.Application/Common/Interfaces/IIdentityService.cs
+++ b/src/main/ML.Application/Common/Interfaces/IIdentityService.cs
@@ -5,6 +5,7 @@ namespace ML.Application.Common.Interfaces;
 public interface IIdentityService
 {
     Task<Result> ChangePasswordAsync(string newPassword);
+    Task<(Result, string usersEmail)> DeactivateAccountAsync();
     Task<Result<LoginDto>> RefreshUserTokenAsync(string encryptedToken);
     Task<Result> RevokeRefreshUserTokenAsync(string encryptedToken);
     Task<Result<LoginDto>> SignInUser(string username, string password);

--- a/src/main/ML.Domain/Constants/ResultMessage.cs
+++ b/src/main/ML.Domain/Constants/ResultMessage.cs
@@ -4,6 +4,8 @@ public class ResultMessage
     public const string AccessTokenGenerated = "Access token generated successfully.";
     public const string ChangePasswordFailed = "You cannot change password at this time.";
     public const string ChangePasswordSuccess = "Your password was changed successfully.";
+    public const string DeactivateAccountFailed = "Your account cannot be deactivated at this time";
+    public const string DeactivateAccountSuccess = "Your account was deactivated successfully";
     public const string LoginFailedGeneric = "Login failed. Please check your credentials.";
     public const string LoginFailedAccountLocked = "Account might be locked out. Please retry in 24 hours";
     public const string SignUpFailed = "Sign up failed. Please review errors and try again.";

--- a/src/main/ML.Infrastructure/Identity/IdentityService.cs
+++ b/src/main/ML.Infrastructure/Identity/IdentityService.cs
@@ -26,6 +26,23 @@ internal class IdentityService(SignInManager<Users> signInManager, UserManager<U
         await signInManager.RefreshSignInAsync(user);
         return Result.Success(ResultMessage.ChangePasswordSuccess);
     }
+    public async Task<(Result, string usersEmail)> DeactivateAccountAsync()
+    {
+        Users? user = await userManager.FindByIdAsync(jwtService.GetUserId().ToString());
+        if (user is null)
+        {
+            return (Result.Failure(ResultMessage.DeactivateAccountFailed, ["Invalid user"]), string.Empty);
+        }
+        if (user.UsersStatus != Domain.Enums.StatusEnum.Active)
+            return (Result.Failure(ResultMessage.DeactivateAccountFailed, ["Account is not active"]), string.Empty);
+        user.UsersStatus = Domain.Enums.StatusEnum.InActive;
+        IdentityResult result = await userManager.UpdateAsync(user);
+        if (!result.Succeeded)
+        {
+            return (result.ToApplicationResult(ResultMessage.DeactivateAccountFailed), string.Empty);
+        }
+        return (Result.Success(ResultMessage.DeactivateAccountSuccess), user.Email!);
+    }
     public async Task<Result<LoginDto>> SignInUser(string username, string password)
     {
         var result = await signInManager.PasswordSignInAsync(username, password, false, true);


### PR DESCRIPTION
Updated `AccountController` to include endpoints for changing passwords and deactivating accounts. Introduced `DeactivateAccountAsync` in `IIdentityService` to handle account deactivation. Enhanced `ResultMessage` with new constants for deactivation success and failure. Implemented `DeactivateAccountAsync` in `IdentityService` to manage user status changes. Created `DeactivateAccountCommand` and its handler to process deactivation requests and send notifications.

#29