### PR TITLE
Add VHost property to RabbitMqSettings configuration

### DIFF
--- a/src/main/ML.Api/appsettings.Development.json
+++ b/src/main/ML.Api/appsettings.Development.json
@@ -57,7 +57,8 @@
   "RabbitMqSettings": {
     "Host": "localhost",
     "UserName": "guest",
-    "Password": ""
+    "Password": "",
+    "VHost": "/"
   },
   "SeedDatabase": true,
   "FEBaseUrl": [ "https://localhost:7275", "http://localhost:7275", "http://localhost:7092" ],

--- a/src/main/ML.Infrastructure/DependencyInjection.cs
+++ b/src/main/ML.Infrastructure/DependencyInjection.cs
@@ -178,7 +178,7 @@ public static class DependencyInjection
             {
                 RabbitMqSettings queueSettings = builder.Configuration.GetSection("RabbitMqSettings").Get<RabbitMqSettings>()!;
 
-                cfg.Host(queueSettings.Host, "/", h =>
+                cfg.Host(queueSettings.Host, queueSettings.VHost, h =>
                 {
                     h.Username(queueSettings.Username!);
                     h.Password(queueSettings.Password!);

--- a/src/main/ML.Infrastructure/Email/RabbitMqSettings.cs
+++ b/src/main/ML.Infrastructure/Email/RabbitMqSettings.cs
@@ -5,4 +5,5 @@ public class RabbitMqSettings
     public string? Host { get; set; }
     public string? Username { get; set; }
     public string? Password { get; set; }
+    public string? VHost { get; set; }
 }

--- a/src/main/ML.Service/Program.cs
+++ b/src/main/ML.Service/Program.cs
@@ -17,7 +17,7 @@ builder.Services.AddMassTransit(config =>
 
     config.UsingRabbitMq((context, cfg) =>
     {
-        cfg.Host(queueSettings.Host, "/", h =>
+        cfg.Host(queueSettings.Host, queueSettings.VHost, h =>
         {
             h.Username(queueSettings.Username!);
             h.Password(queueSettings.Password!);

--- a/src/main/ML.Service/appsettings.json
+++ b/src/main/ML.Service/appsettings.json
@@ -24,6 +24,7 @@
   "RabbitMqSettings": {
     "Host": "localhost",
     "UserName": "guest",
-    "Password": ""
+    "Password": "",
+    "VHost": "/"
   }
 }


### PR DESCRIPTION
Updated appsettings files to include a new `VHost` property under `RabbitMqSettings`, set to `/`. Modified `DependencyInjection.cs` and `Program.cs` to utilize this new property for RabbitMQ host configuration, enhancing flexibility. Updated `RabbitMqSettings.cs` to support the new property.