### PR TITLE
Update appsettings and improve timestamp handling

### DIFF
--- a/src/main/ML.Api/appsettings.json
+++ b/src/main/ML.Api/appsettings.json
@@ -5,5 +5,49 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "ConnectionStrings": {
+    "DefaultConnection": "",
+    "RedisConnection": ""
+  },
+  "ApiKey": "",
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "fileSizeLimitBytes": 10000000,
+          "path": "logs/log.txt",
+          "rollingInterval": "Hour",
+          "rollOnFileSizeLimit": true,
+          "retainedFileCountLimit": 1000,
+          "retainedFileTimeLimit": "5.00:00:00"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
+  },
+  "JwtSettings": {
+    "Secret": "",
+    "Issuer": "ML.Api",
+    "Audience": "ML.Client",
+    "ExpirationInMinutes": 10
+  },
+  "OpenVerseSettings": {
+    "BaseUrl": "https://api.openverse.org",
+    "GrantType": "client_credentials",
+    "ClientId": "",
+    "ClientSecret": ""
+  },
+  "SeedDatabase": true
 }

--- a/src/main/ML.Infrastructure/Data/MLDbContextInitialiser.cs
+++ b/src/main/ML.Infrastructure/Data/MLDbContextInitialiser.cs
@@ -73,12 +73,12 @@ public class MLDbContextInitialiser(ILogger<MLDbContextInitialiser> logger, MLDb
 
         Users administrator = new()
         {
-            Created = DateTimeOffset.Now,
+            Created = DateTimeOffset.UtcNow,
             CreatedBy = "System",
             Email = "princeizak@live.com",
             EmailConfirmed = true,
             FirstName = "Isaac",
-            LastModified = DateTimeOffset.Now,
+            LastModified = DateTimeOffset.UtcNow,
             LastName = "Ose",
             PhoneNumber = "07000000000",
             PhoneNumberConfirmed = true,


### PR DESCRIPTION
Enhanced `appsettings.json` with new configuration settings, including `ConnectionStrings`, `ApiKey`, `Serilog` logging options, `JwtSettings`, and `OpenVerseSettings`. Set `SeedDatabase` to true for automatic seeding.

Modified `MLDbContextInitialiser.cs` to use `DateTimeOffset.UtcNow` for `Created` and `LastModified` properties, ensuring consistent UTC timestamp recording.