### PR TITLE
Remove ClientSecret from OpenVerseSettings

### DIFF
--- a/src/main/ML.Api/appsettings.json
+++ b/src/main/ML.Api/appsettings.json
@@ -48,6 +48,5 @@
     "GrantType": "client_credentials",
     "ClientId": "",
     "ClientSecret": ""
-  },
-  "SeedDatabase": true
+  }
 }


### PR DESCRIPTION
Removed the `ClientSecret` key from the `OpenVerseSettings` section in `appsettings.json`. The closing brace for the `OpenVerseSettings` object was moved to a new line, and the `SeedDatabase` key remains as `true`, now positioned outside of the `OpenVerseSettings` object.